### PR TITLE
don't fail rubocop b/c of framework environment files with many code lines

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
 
 Metrics/BlockLength:
   Exclude:
+    - 'config/environments/*'
     - 'config/routes.rb'
     - 'spec/**/*'
 


### PR DESCRIPTION
Default development config has 27 lines, rubocop says it wants 25 max, just turning off that requirement for configs.

It's a pretty stringent line requirement, but I sort of lean draconian and want somebody to _FEEL IT_ if they adjust that globally for an app so that's why I'm excluding the rule from the directory instead of bumping up the count.