### PR TITLE
skip rubocop block length check for environments config files (automatic failure on install)

### DIFF
--- a/app/templates/files/.rubocop.yml
+++ b/app/templates/files/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
 
 Metrics/BlockLength:
   Exclude:
+    - 'config/environments/*'
     - 'config/routes.rb'
     - 'spec/**/*'
 


### PR DESCRIPTION
The boilerplate fails when it really shouldn't, let's just kill this rubocop rule for these files.