### PR TITLE
3034 punt on public pages stylelint / warn about Rails 7

### DIFF
--- a/app/templates/scripts/_webpacker.erb
+++ b/app/templates/scripts/_webpacker.erb
@@ -15,7 +15,7 @@
 
   puts "\nConfigure stylelint + apply to generated files"
   create_file '.stylelintrc', <%= file_as_quoted_string '.stylelintrc' %>
-  run 'yarn stylelint --fix public/*.html'
+  # Rails generates error pages that can't automatically be fixed by this at the moment: run 'yarn stylelint --fix public/*.html --custom-syntax=postcss-html'
 
   puts "\nCreating Procfile"
   create_file 'Procfile', "rails: bin/rails s -p \"${#{@app_name.underscore.upcase}_PORT:-3000}\"\nwebpacker: bin/webpack-dev-server"

--- a/app/templates/scripts/_yarn_packages.erb
+++ b/app/templates/scripts/_yarn_packages.erb
@@ -1,4 +1,4 @@
 
 puts "\nAdding packages"
 run "yarn add jquery jquery-ujs bootstrap popper.js stylelint stylelint-config-standard"
-run "yarn add --dev babel-jest jest jest-junit"
+run "yarn add --dev babel-jest jest jest-junit postcss-html"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,5 @@
+#_⚠ WARNING!! The generator currently requires Rails < 7 due to the migration away from webpacker for FE assets; Update coming soon! ⚠_
+
 # Rails Template Generator
 
 [github.com/Beyond-Finance/rails-template-generator](https://github.com/Beyond-Finance/rails-template-generator/)


### PR DESCRIPTION
Just a couple little things to stopgap us until I get around to updating all the webpacker scripts to jsbundling scripts.

Somewhere around 6.1.4._something_ the default public error pages Rails generates insert style rules that can't be automatically resolved, they require manual intervention. And, stylelint can't even figure that out without the addition of a postcss-html module as of its latest version as well.

Which causes the setup to barf, so this adds what we need for stylelint on html, but skips that step for now while Rails is creating the unsolvable problem (it's about how it arranges its border color styles for an alert box, wa-waa).

And, just adding a temporary warning to the docs about not being able to create Rails 7 apps (yet)